### PR TITLE
feat: use hashed alternatives

### DIFF
--- a/app/lib/utils/core.ts
+++ b/app/lib/utils/core.ts
@@ -1,10 +1,10 @@
 import * as cryptoServer from "crypto";
 import { StandaloneQuestion } from "@/classes/standalone-question";
 
-const containsAll = (arr1: number[], arr2: number[]) =>
+export const containsAll = (arr1: (number | string)[], arr2: (number | string)[]) =>
   arr2?.every((arr2Item) => arr1?.includes(arr2Item));
 
-const sameMembers = (arr1: number[], arr2: number[]) =>
+export const sameMembers = (arr1: (number | string)[], arr2: (number | string)[]) =>
   containsAll(arr1, arr2) && containsAll(arr2, arr1);
 
 export const getCorrectAnswers = (questions: StandaloneQuestion[]) => {
@@ -63,4 +63,31 @@ export function getRandomUUID() {
     return cryptoServer.randomBytes(16).toString("hex");
   }
   return crypto.randomUUID();
+}
+
+/**
+ * Generates a hash code for the given source string or array of strings.
+ *
+ * If the source is an array, it joins the elements into a single string using a space as the separator.
+ * Then, it calculates a hash code using a simple algorithm that iterates over each character in the string.
+ * The algorithm multiplies the current hash value by 31 (a prime number), subtracts the hash value, and adds the ASCII value of the current character.
+ * The final hash value is converted to a 32-bit integer using the bitwise OR operator with zero.
+ *
+ * @param source - The source string or array of strings to generate the hash code for.
+ * @returns The hash code for the given source.
+ */
+export function hashCode(source: string | string[]) {
+  if (Array.isArray(source)) {
+    return source.join(" ");
+  }
+  let hash = 0,
+    i,
+    chr;
+  if (source.length === 0) return hash;
+  for (i = 0; i < source.length; i++) {
+    chr = source.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return hash;
 }

--- a/classes/standalone-question.ts
+++ b/classes/standalone-question.ts
@@ -1,4 +1,4 @@
-import { getRandomUUID } from "@/app/lib/utils/core";
+import { getRandomUUID, hashCode } from "@/app/lib/utils/core";
 import { ImportedQuestion } from "@/interfaces/imported-question";
 import { micromark } from "micromark";
 
@@ -11,7 +11,9 @@ export class StandaloneQuestion {
       defaultLineEnding: "\n",
     });
     this.command = this.command.replaceAll("<code>", '<code class="language-abap">');
-    this.alternatives = alternatives.map((a) => a.label);
+    this.alternatives = alternatives.map((a) => {
+      return { label: a.label, hash: hashCode(a.label) };
+    });
     this.answers = alternatives.reduce((prev, a, i) => {
       if (a.isCorrect) return [...prev, i];
       return prev;
@@ -23,9 +25,12 @@ export class StandaloneQuestion {
 
   id: string;
   command: string | null;
-  alternatives: string[];
-  answers: number[];
-  checkedAlternatives: number[];
+  alternatives: {
+    label: string;
+    hash: string | number;
+  }[];
+  answers: (number | string)[];
+  checkedAlternatives: (number | string)[];
   questionSetId: string | null;
   authorId: string | null;
 }

--- a/classes/standalone-question.ts
+++ b/classes/standalone-question.ts
@@ -14,10 +14,10 @@ export class StandaloneQuestion {
     this.alternatives = alternatives.map((a) => {
       return { label: a.label, hash: hashCode(a.label) };
     });
-    this.answers = alternatives.reduce((prev, a, i) => {
-      if (a.isCorrect) return [...prev, i];
+    this.answers = alternatives.reduce((prev, a) => {
+      if (a.isCorrect) return [...prev, hashCode(a.label)];
       return prev;
-    }, [] as number[]);
+    }, [] as (number | string)[]);
     this.questionSetId = null;
     this.checkedAlternatives = [];
     this.authorId = null;

--- a/components/exam-result.tsx
+++ b/components/exam-result.tsx
@@ -9,11 +9,10 @@ import { Dispatch, Fragment, SetStateAction, useCallback } from "react";
 import { Kbd } from "./kbd";
 import { AppSetting, db } from "@/db/db.model";
 import { useLiveQuery } from "dexie-react-hooks";
-import { StandaloneQuestion } from "@/classes/standalone-question";
 
 type ExamResultProps = {
   setShowResultsPage: Dispatch<SetStateAction<boolean>>;
-  resetExam: (questions: StandaloneQuestion[]) => void;
+  resetExam: () => void;
 };
 
 const buttonStyle = `px-3 py-2 mr-2 text-white rounded cursor-pointer  disabled:text-slate-300 disabled:bg-slate-500`;
@@ -52,15 +51,11 @@ export default function ExamResult({ setShowResultsPage, resetExam }: ExamResult
 
   const results = getResults();
 
-  const triggerResetExam = () => {
-    resetExam(questions);
-  };
-
   const isKeyboardCapable = useKeyboardNavigationResults({
     setShowAnsweredOnly,
     showAnsweredOnly,
     setShowResultsPage,
-    triggerResetExam,
+    resetExam,
   });
 
   return (
@@ -83,7 +78,7 @@ export default function ExamResult({ setShowResultsPage, resetExam }: ExamResult
       <p className="justify-center mb-6 flex gap-2">
         <button
           className={buttonStyle + ` bg-rose-950 hover:bg-rose-900`}
-          onClick={() => triggerResetExam()}
+          onClick={() => resetExam()}
         >
           Limpar respostas marcadas {isKeyboardCapable && <Kbd>Del</Kbd>}
         </button>

--- a/components/exam-result.tsx
+++ b/components/exam-result.tsx
@@ -1,4 +1,8 @@
-import { getCorrectAnswers, getPercentFromTotal } from "@/app/lib/utils/core";
+import {
+  getCorrectAnswers,
+  getPercentFromTotal,
+  sameMembers,
+} from "@/app/lib/utils/core";
 import { useKeyboardNavigationResults } from "@/hooks/use-keyboard-navigation-results";
 import { useSyntaxHighlighting } from "@/hooks/use-syntax-highlighting";
 import { Dispatch, Fragment, SetStateAction, useCallback } from "react";
@@ -14,11 +18,6 @@ type ExamResultProps = {
 
 const buttonStyle = `px-3 py-2 mr-2 text-white rounded cursor-pointer  disabled:text-slate-300 disabled:bg-slate-500`;
 const buttonColors = `bg-slate-700 hover:bg-slate-600`;
-const containsAll = (arr1: number[], arr2: number[]) =>
-  arr2?.every((arr2Item) => arr1?.includes(arr2Item));
-
-const sameMembers = (arr1: number[], arr2: number[]) =>
-  containsAll(arr1, arr2) && containsAll(arr2, arr1);
 
 export default function ExamResult({ setShowResultsPage, resetExam }: ExamResultProps) {
   const showAnsweredOnly =
@@ -136,8 +135,8 @@ export default function ExamResult({ setShowResultsPage, resetExam }: ExamResult
               </h3>
               <div className="ml-6 my-1">
                 {alternatives.map((alt, idx) => {
-                  const wasChosen = checkedAlternatives?.includes(idx);
-                  const isCorrect = answers.includes(idx);
+                  const wasChosen = checkedAlternatives?.includes(alt.hash);
+                  const isCorrect = answers.includes(alt.hash);
                   const type = answers.length > 1 ? "checkbox" : "radio";
                   return (
                     <div
@@ -148,11 +147,14 @@ export default function ExamResult({ setShowResultsPage, resetExam }: ExamResult
                           : "bg-red-100 border-red-600"
                       }`}
                     >
-                      <label className={`flex items-center`}>
+                      <label
+                        className={`flex items-center`}
+                        id={`${question.id}-${alt.label}`}
+                      >
                         <input type={type} readOnly checked={wasChosen} />
                         <span
                           className="ml-1 select-none"
-                          dangerouslySetInnerHTML={{ __html: alt }}
+                          dangerouslySetInnerHTML={{ __html: alt.label }}
                         ></span>
                       </label>
                     </div>

--- a/components/exam-result.tsx
+++ b/components/exam-result.tsx
@@ -149,7 +149,7 @@ export default function ExamResult({ setShowResultsPage, resetExam }: ExamResult
                     >
                       <label
                         className={`flex items-center`}
-                        id={`${question.id}-${alt.label}`}
+                        id={`${question.id}-${alt.hash}`}
                       >
                         <input type={type} readOnly checked={wasChosen} />
                         <span

--- a/db/db.model.ts
+++ b/db/db.model.ts
@@ -37,23 +37,25 @@ export class DB extends Dexie {
 const db = new DB();
 
 // Convert pre-hashed alternatives to hashed alternatives.
-db.questions.toArray().then(async (questions) => {
-  if (questions.length && !questions[0].alternatives[0]?.hash) {
-    const hashedQuestions = questions.map((q: any) => {
-      q.alternatives = q.alternatives.map((a: string) => {
-        return { label: a, hash: hashCode(a) };
+if (global?.indexedDB) {
+  db.questions.toArray().then(async (questions) => {
+    if (questions.length && !questions[0].alternatives[0]?.hash) {
+      const hashedQuestions = questions.map((q: any) => {
+        q.alternatives = q.alternatives.map((a: string) => {
+          return { label: a, hash: hashCode(a) };
+        });
+        q.answers = q.answers.map((a: number) => {
+          return q.alternatives[a].hash;
+        });
+        q.checkedAlternatives = q.checkedAlternatives.map((ca: number) => {
+          return q.alternatives[ca].hash;
+        });
+        return q as StandaloneQuestion;
       });
-      q.answers = q.answers.map((a: number) => {
-        return q.alternatives[a].hash;
-      });
-      q.checkedAlternatives = q.checkedAlternatives.map((ca: number) => {
-        return q.alternatives[ca].hash;
-      });
-      return q as StandaloneQuestion;
-    });
-    await db.questions.clear();
-    await db.questions.bulkAdd(hashedQuestions);
-  }
-});
+      await db.questions.clear();
+      await db.questions.bulkAdd(hashedQuestions);
+    }
+  });
+}
 
 export { db }; // export the db

--- a/hooks/use-keyboard-navigation-exam.ts
+++ b/hooks/use-keyboard-navigation-exam.ts
@@ -19,11 +19,11 @@ export function useKeyboardNavigationExam({
     const isTouchDevice = () => "ontouchstart" in window || "onmsgesturechange" in window;
     const isDesktop = window.screenX != 0 && !isTouchDevice() ? true : false;
     setIsKeyboardCapable(isDesktop);
-    const handleKeyDown = (e: KeyboardEvent) => {
+    const handleKeydown = (e: KeyboardEvent) => {
       setIsKeyboardCapable(true);
-      const inputs = document?.querySelectorAll("input");
+      const inputs = Array.from(document?.querySelectorAll("input"));
       const focused = (document?.querySelector("input:focus") as HTMLInputElement) ?? 0;
-      const focusedIndex = Number(focused?.dataset?.index ?? 0);
+      const focusedIndex = inputs.indexOf(focused);
       switch (e.key) {
         case "ArrowLeft":
           e.preventDefault();
@@ -71,7 +71,6 @@ export function useKeyboardNavigationExam({
         case "ArrowDown":
           e.preventDefault();
           if (focusedIndex < inputs.length - 1) {
-            console.debug(inputs[focusedIndex + 1]);
             inputs[focusedIndex + 1]?.focus();
           }
           break;
@@ -79,9 +78,9 @@ export function useKeyboardNavigationExam({
           break;
       }
     };
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeydown);
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeydown);
     };
   }, [
     currentQuestion,

--- a/hooks/use-keyboard-navigation-results.ts
+++ b/hooks/use-keyboard-navigation-results.ts
@@ -4,14 +4,14 @@ type UseKeyboardNavigationExamOptions = {
   setShowResultsPage: Dispatch<SetStateAction<boolean>>;
   showAnsweredOnly: boolean;
   setShowAnsweredOnly: (value: boolean) => void;
-  triggerResetExam: () => void;
+  resetExam: () => void;
 };
 
 export function useKeyboardNavigationResults({
   setShowResultsPage,
   showAnsweredOnly,
   setShowAnsweredOnly: setShowOnlyAnsweredQuestions,
-  triggerResetExam,
+  resetExam,
 }: UseKeyboardNavigationExamOptions) {
   const [isKeyboardCapable, setIsKeyboardCapable] = useState(true);
   useEffect(() => {
@@ -28,7 +28,7 @@ export function useKeyboardNavigationResults({
           break;
         case "Delete":
           e.preventDefault();
-          triggerResetExam();
+          resetExam();
           break;
         case "q":
           e.preventDefault();
@@ -42,11 +42,6 @@ export function useKeyboardNavigationResults({
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [
-    setShowResultsPage,
-    setShowOnlyAnsweredQuestions,
-    showAnsweredOnly,
-    triggerResetExam,
-  ]);
+  }, [setShowResultsPage, setShowOnlyAnsweredQuestions, showAnsweredOnly, resetExam]);
   return isKeyboardCapable;
 }


### PR DESCRIPTION
Now the questions import code generates a numeric hash for every alternative, which make alternatives and answers index-independent. 

This fixes a bug where all correct answers become incorrect once "clean marked answers" button in results page is clicked.
